### PR TITLE
add a redundant rawtx field of getblock RPC for lbcd compatibility

### DIFF
--- a/daemon/processing/block.go
+++ b/daemon/processing/block.go
@@ -147,7 +147,11 @@ func processGenesisBlock() error {
 	BlockLock.Lock()
 	defer BlockLock.Unlock()
 	block := parseBlockInfo(0, genesis)
-	for _, tx := range genesisVerbose.Tx {
+	txs := genesisVerbose.Tx
+	if len(txs) == 0 {
+		txs = genesisVerbose.RawTx
+	}
+	for _, tx := range txs {
 		tx.BlockHash = genesis.Hash
 		err := ProcessTx(&tx, block.BlockTime, 0)
 		if err != nil {

--- a/daemon/processing/block.go
+++ b/daemon/processing/block.go
@@ -149,6 +149,7 @@ func processGenesisBlock() error {
 	block := parseBlockInfo(0, genesis)
 	txs := genesisVerbose.Tx
 	if len(txs) == 0 {
+		// This is to support lbcd which treats verbose output as a different field unlike lbrycrd
 		txs = genesisVerbose.RawTx
 	}
 	for _, tx := range txs {

--- a/lbrycrd/reponse.go
+++ b/lbrycrd/reponse.go
@@ -81,6 +81,7 @@ type GetBlockVerboseResponse struct {
 	MerkleRoot        string        `json:"merkleroot"`
 	NameClaimRoot     string        `json:"nameclaimroot"`
 	Tx                []TxRawResult `json:"tx,omitempty"`
+	RawTx             []TxRawResult `json:"rawtx,omitempty"`
 	Time              int64         `json:"time"`
 	MedianTime        int64         `json:"mediantime"`
 	Nonce             uint64        `json:"nonce"`


### PR DESCRIPTION
The tx field in getblock response has different formats depends on the
verbosity level.  While lbrycrd/bitcoind use the same field name, lbcd
treats them as separate fields.

Later on, if lbcd ends up using the same field name, this commit can be
reverted.