### PR TITLE
Fix for Dockerfile smell DL3048

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ## Get the latest source and extract it for the app container.
 ## Design choices, two RUN layers intended to keep builds faster, the zipped
 FROM ubuntu:18.04 as prep
-LABEL MAINTAINER="beamer@lbry.io"
+LABEL maintainer="beamer@lbry.io"
 RUN apt-get update && \
   apt-get -y install unzip curl telnet wait-for-it && \
   apt-get autoclean -y && \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We manually checked that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.